### PR TITLE
feature: added ability for commands to have multiple permissions

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     `kotlin-dsl`
+    `maven-publish`
 }
 
 repositories {

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     `kotlin-dsl`
-    `maven-publish`
 }
 
 repositories {

--- a/core/src/main/java/dev/triumphteam/cmd/core/argument/named/Arguments.java
+++ b/core/src/main/java/dev/triumphteam/cmd/core/argument/named/Arguments.java
@@ -56,7 +56,7 @@ public interface Arguments {
 
     /**
      * Check if no arguments are passed
-     * @returns true if no arguments have been passed in the command
+     * @return true if no arguments have been passed in the command
      */
     boolean isEmpty();
 }

--- a/minecraft/bukkit/src/main/java/dev/triumphteam/cmd/bukkit/BukkitCommand.java
+++ b/minecraft/bukkit/src/main/java/dev/triumphteam/cmd/bukkit/BukkitCommand.java
@@ -168,6 +168,12 @@ public final class BukkitCommand<S> extends org.bukkit.command.Command implement
         return subCommands.containsKey(key) || subCommandAliases.containsKey(key);
     }
 
+    /**
+     * Checks if a {@link CommandSender} has any of the permissions from a {@link List<CommandPermission>}
+     * @param permissions The list of permissions
+     * @param sender
+     * @return true if the sender has any of the permissions in the list
+     */
     private boolean hasPermission(@NotNull final List<CommandPermission> permissions, @NotNull final CommandSender sender) {
         return permissions.stream().anyMatch(p -> sender.hasPermission(p.getNode()));
     }

--- a/minecraft/bukkit/src/main/java/dev/triumphteam/cmd/bukkit/BukkitCommand.java
+++ b/minecraft/bukkit/src/main/java/dev/triumphteam/cmd/bukkit/BukkitCommand.java
@@ -37,10 +37,8 @@ import org.bukkit.command.CommandSender;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyList;
@@ -93,9 +91,9 @@ public final class BukkitCommand<S> extends org.bukkit.command.Command implement
             return true;
         }
 
-        final CommandPermission permission = subCommand.getPermission();
-        if (permission != null && !permission.hasPermission(sender)) {
-            messageRegistry.sendMessage(BukkitMessageKey.NO_PERMISSION, mappedSender, new NoPermissionMessageContext(getName(), subCommand.getName(), permission.getNode()));
+        final ArrayList<CommandPermission> permissions = subCommand.getPermissions();
+        if (permissions != null && !hasPermission(permissions, sender)) {
+            messageRegistry.sendMessage(BukkitMessageKey.NO_PERMISSION, mappedSender, new NoPermissionMessageContext(getName(), subCommand.getName(), permissions.get(0).getNode()));
             return true;
         }
 
@@ -118,9 +116,9 @@ public final class BukkitCommand<S> extends org.bukkit.command.Command implement
                     .filter(it -> !it.getValue().isDefault())
                     .filter(it -> it.getKey().startsWith(arg))
                     .filter(it -> {
-                        final CommandPermission permission = it.getValue().getPermission();
-                        if (permission == null) return false;
-                        return permission.hasPermission(sender);
+                        final ArrayList<CommandPermission> permissions = it.getValue().getPermissions();
+                        if (permissions == null) return false;
+                        return hasPermission(permissions, sender);
                     })
                     .map(Map.Entry::getKey)
                     .collect(Collectors.toList());
@@ -129,8 +127,8 @@ public final class BukkitCommand<S> extends org.bukkit.command.Command implement
         if (subCommandExists(arg)) subCommand = getSubCommand(arg);
         if (subCommand == null) return emptyList();
 
-        final CommandPermission permission = subCommand.getPermission();
-        if (permission != null && !permission.hasPermission(sender)) return emptyList();
+        final ArrayList<CommandPermission> permissions = subCommand.getPermissions();
+        if (permissions != null && hasPermission(permissions, sender)) return emptyList();
 
         final S mappedSender = senderMapper.map(sender);
 
@@ -169,5 +167,14 @@ public final class BukkitCommand<S> extends org.bukkit.command.Command implement
      */
     private boolean subCommandExists(@NotNull final String key) {
         return subCommands.containsKey(key) || subCommandAliases.containsKey(key);
+    }
+
+    private boolean hasPermission(@NotNull final ArrayList<CommandPermission> permissions, @NotNull final CommandSender sender) {
+        AtomicBoolean hasPermission = new AtomicBoolean(false);
+        permissions.forEach(permission -> {
+            if(sender.hasPermission(permission.getNode())) hasPermission.set(true);
+        });
+
+        return hasPermission.get();
     }
 }

--- a/minecraft/bukkit/src/main/java/dev/triumphteam/cmd/bukkit/BukkitCommand.java
+++ b/minecraft/bukkit/src/main/java/dev/triumphteam/cmd/bukkit/BukkitCommand.java
@@ -172,7 +172,9 @@ public final class BukkitCommand<S> extends org.bukkit.command.Command implement
     private boolean hasPermission(@NotNull final ArrayList<CommandPermission> permissions, @NotNull final CommandSender sender) {
         AtomicBoolean hasPermission = new AtomicBoolean(false);
         permissions.forEach(permission -> {
-            if(sender.hasPermission(permission.getNode())) hasPermission.set(true);
+            if(sender.hasPermission(permission.getNode())) {
+                hasPermission.set(true);
+            }
         });
 
         return hasPermission.get();

--- a/minecraft/bukkit/src/main/java/dev/triumphteam/cmd/bukkit/BukkitCommand.java
+++ b/minecraft/bukkit/src/main/java/dev/triumphteam/cmd/bukkit/BukkitCommand.java
@@ -91,7 +91,7 @@ public final class BukkitCommand<S> extends org.bukkit.command.Command implement
             return true;
         }
 
-        final ArrayList<CommandPermission> permissions = subCommand.getPermissions();
+        final List<CommandPermission> permissions = subCommand.getPermissions();
         if (permissions != null && !hasPermission(permissions, sender)) {
             messageRegistry.sendMessage(BukkitMessageKey.NO_PERMISSION, mappedSender, new NoPermissionMessageContext(getName(), subCommand.getName(), permissions.get(0).getNode()));
             return true;
@@ -116,7 +116,7 @@ public final class BukkitCommand<S> extends org.bukkit.command.Command implement
                     .filter(it -> !it.getValue().isDefault())
                     .filter(it -> it.getKey().startsWith(arg))
                     .filter(it -> {
-                        final ArrayList<CommandPermission> permissions = it.getValue().getPermissions();
+                        final List<CommandPermission> permissions = it.getValue().getPermissions();
                         if (permissions == null) return false;
                         return hasPermission(permissions, sender);
                     })
@@ -127,7 +127,7 @@ public final class BukkitCommand<S> extends org.bukkit.command.Command implement
         if (subCommandExists(arg)) subCommand = getSubCommand(arg);
         if (subCommand == null) return emptyList();
 
-        final ArrayList<CommandPermission> permissions = subCommand.getPermissions();
+        final List<CommandPermission> permissions = subCommand.getPermissions();
         if (permissions != null && hasPermission(permissions, sender)) return emptyList();
 
         final S mappedSender = senderMapper.map(sender);
@@ -169,7 +169,7 @@ public final class BukkitCommand<S> extends org.bukkit.command.Command implement
         return subCommands.containsKey(key) || subCommandAliases.containsKey(key);
     }
 
-    private boolean hasPermission(@NotNull final ArrayList<CommandPermission> permissions, @NotNull final CommandSender sender) {
+    private boolean hasPermission(@NotNull final List<CommandPermission> permissions, @NotNull final CommandSender sender) {
         AtomicBoolean hasPermission = new AtomicBoolean(false);
         permissions.forEach(permission -> {
             if(sender.hasPermission(permission.getNode())) {

--- a/minecraft/bukkit/src/main/java/dev/triumphteam/cmd/bukkit/BukkitCommand.java
+++ b/minecraft/bukkit/src/main/java/dev/triumphteam/cmd/bukkit/BukkitCommand.java
@@ -38,7 +38,6 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyList;
@@ -170,13 +169,6 @@ public final class BukkitCommand<S> extends org.bukkit.command.Command implement
     }
 
     private boolean hasPermission(@NotNull final List<CommandPermission> permissions, @NotNull final CommandSender sender) {
-        AtomicBoolean hasPermission = new AtomicBoolean(false);
-        permissions.forEach(permission -> {
-            if(sender.hasPermission(permission.getNode())) {
-                hasPermission.set(true);
-            }
-        });
-
-        return hasPermission.get();
+        return permissions.stream().anyMatch(p -> sender.hasPermission(p.getNode()));
     }
 }

--- a/minecraft/bukkit/src/main/java/dev/triumphteam/cmd/bukkit/BukkitCommandManager.java
+++ b/minecraft/bukkit/src/main/java/dev/triumphteam/cmd/bukkit/BukkitCommandManager.java
@@ -65,7 +65,7 @@ public final class BukkitCommandManager<S> extends CommandManager<CommandSender,
     private final CommandMap commandMap;
     private final Map<String, org.bukkit.command.Command> bukkitCommands;
 
-    private String[] basePermission = {""};
+    private String[] basePermissions = {""};
 
     private BukkitCommandManager(
             @NotNull final Plugin plugin,
@@ -127,7 +127,7 @@ public final class BukkitCommandManager<S> extends CommandManager<CommandSender,
                 getSenderValidator(),
                 syncExecutionProvider,
                 asyncExecutionProvider,
-                basePermission
+                basePermissions
         );
 
         final BukkitCommand<S> command = commands.computeIfAbsent(processor.getName(), ignored -> createAndRegisterCommand(processor.getName(), processor));
@@ -146,13 +146,13 @@ public final class BukkitCommandManager<S> extends CommandManager<CommandSender,
         // TODO add a remove functionality
     }
 
-    public void setBasePermission(@NotNull final String[] basePermission) {
-        this.basePermission = basePermission;
+    public void setBasePermissions(@NotNull final String[] basePermissions) {
+        this.basePermissions = basePermissions;
     }
 
     @NotNull
-    public String[] getBasePermission() {
-        return basePermission;
+    public String[] getBasePermissions() {
+        return basePermissions;
     }
 
     @NotNull

--- a/minecraft/bukkit/src/main/java/dev/triumphteam/cmd/bukkit/BukkitCommandManager.java
+++ b/minecraft/bukkit/src/main/java/dev/triumphteam/cmd/bukkit/BukkitCommandManager.java
@@ -144,16 +144,7 @@ public final class BukkitCommandManager<S> extends CommandManager<CommandSender,
     public void unregisterCommand(@NotNull final BaseCommand command) {
         // TODO add a remove functionality
     }
-
-    public void setBasePermissions(@NotNull final List<String> basePermissions) {
-        this.basePermissions = basePermissions;
-    }
-
-    @NotNull
-    public List<String> getBasePermissions() {
-        return basePermissions;
-    }
-
+    
     @NotNull
     @Override
     protected RegistryContainer<S> getRegistryContainer() {

--- a/minecraft/bukkit/src/main/java/dev/triumphteam/cmd/bukkit/BukkitCommandManager.java
+++ b/minecraft/bukkit/src/main/java/dev/triumphteam/cmd/bukkit/BukkitCommandManager.java
@@ -48,8 +48,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 
 public final class BukkitCommandManager<S> extends CommandManager<CommandSender, S> {
@@ -65,7 +64,7 @@ public final class BukkitCommandManager<S> extends CommandManager<CommandSender,
     private final CommandMap commandMap;
     private final Map<String, org.bukkit.command.Command> bukkitCommands;
 
-    private String[] basePermissions = {""};
+    private List<String> basePermissions = Collections.singletonList("");
 
     private BukkitCommandManager(
             @NotNull final Plugin plugin,
@@ -146,12 +145,12 @@ public final class BukkitCommandManager<S> extends CommandManager<CommandSender,
         // TODO add a remove functionality
     }
 
-    public void setBasePermissions(@NotNull final String[] basePermissions) {
+    public void setBasePermissions(@NotNull final List<String> basePermissions) {
         this.basePermissions = basePermissions;
     }
 
     @NotNull
-    public String[] getBasePermissions() {
+    public List<String> getBasePermissions() {
         return basePermissions;
     }
 

--- a/minecraft/bukkit/src/main/java/dev/triumphteam/cmd/bukkit/BukkitCommandManager.java
+++ b/minecraft/bukkit/src/main/java/dev/triumphteam/cmd/bukkit/BukkitCommandManager.java
@@ -65,7 +65,7 @@ public final class BukkitCommandManager<S> extends CommandManager<CommandSender,
     private final CommandMap commandMap;
     private final Map<String, org.bukkit.command.Command> bukkitCommands;
 
-    private String basePermission = "";
+    private String[] basePermission = {""};
 
     private BukkitCommandManager(
             @NotNull final Plugin plugin,
@@ -146,12 +146,12 @@ public final class BukkitCommandManager<S> extends CommandManager<CommandSender,
         // TODO add a remove functionality
     }
 
-    public void setBasePermission(@NotNull final String basePermission) {
+    public void setBasePermission(@NotNull final String[] basePermission) {
         this.basePermission = basePermission;
     }
 
     @NotNull
-    public String getBasePermission() {
+    public String[] getBasePermission() {
         return basePermission;
     }
 

--- a/minecraft/bukkit/src/main/java/dev/triumphteam/cmd/bukkit/BukkitCommandProcessor.java
+++ b/minecraft/bukkit/src/main/java/dev/triumphteam/cmd/bukkit/BukkitCommandProcessor.java
@@ -39,7 +39,7 @@ import java.util.*;
 
 final class BukkitCommandProcessor<S> extends AbstractCommandProcessor<CommandSender, S, BukkitSubCommand<S>, BukkitSubCommandProcessor<S>> {
 
-    private final ArrayList<CommandPermission> basePermissions;
+    private final List<CommandPermission> basePermissions;
 
     public BukkitCommandProcessor(
             @NotNull final BaseCommand baseCommand,
@@ -88,13 +88,13 @@ final class BukkitCommandProcessor<S> extends AbstractCommandProcessor<CommandSe
         return new BukkitSubCommand<>(processor, getName(), executionProvider);
     }
 
-    static ArrayList<CommandPermission> createPermissions(
+    static List<CommandPermission> createPermissions(
             @NotNull final String[] parentNode, // TODO determine usage?
             @NotNull final String[] node,
             @NotNull final String description,
             @NotNull final PermissionDefault permissionDefault
     ) {
-        ArrayList<CommandPermission> permissions = new ArrayList<>();
+        List<CommandPermission> permissions = new ArrayList<>();
         for (String permission : node) {
             permissions.add(new CommandPermission(permission, description, permissionDefault));
         }

--- a/minecraft/bukkit/src/main/java/dev/triumphteam/cmd/bukkit/BukkitCommandProcessor.java
+++ b/minecraft/bukkit/src/main/java/dev/triumphteam/cmd/bukkit/BukkitCommandProcessor.java
@@ -36,6 +36,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.lang.reflect.Method;
 import java.util.*;
+import java.util.stream.Collectors;
 
 final class BukkitCommandProcessor<S> extends AbstractCommandProcessor<CommandSender, S, BukkitSubCommand<S>, BukkitSubCommandProcessor<S>> {
 
@@ -48,7 +49,7 @@ final class BukkitCommandProcessor<S> extends AbstractCommandProcessor<CommandSe
             @NotNull final SenderValidator<S> senderValidator,
             @NotNull final ExecutionProvider syncExecutionProvider,
             @NotNull final ExecutionProvider asyncExecutionProvider,
-            @NotNull final String[] globalBasePermissions
+            @NotNull final List<String> globalBasePermissions
     ) {
         super(baseCommand, registryContainer, senderMapper, senderValidator, syncExecutionProvider, asyncExecutionProvider);
 
@@ -60,7 +61,7 @@ final class BukkitCommandProcessor<S> extends AbstractCommandProcessor<CommandSe
 
         this.basePermissions = createPermissions(
                 globalBasePermissions,
-                annotation.value(),
+                Arrays.stream(annotation.value()).collect(Collectors.toList()),
                 annotation.description(),
                 annotation.def()
         );
@@ -89,8 +90,8 @@ final class BukkitCommandProcessor<S> extends AbstractCommandProcessor<CommandSe
     }
 
     static List<CommandPermission> createPermissions(
-            @NotNull final String[] parentNode, // TODO determine usage?
-            @NotNull final String[] node,
+            @NotNull final List<String> parentNode,
+            @NotNull final List<String> node,
             @NotNull final String description,
             @NotNull final PermissionDefault permissionDefault
     ) {

--- a/minecraft/bukkit/src/main/java/dev/triumphteam/cmd/bukkit/BukkitCommandProcessor.java
+++ b/minecraft/bukkit/src/main/java/dev/triumphteam/cmd/bukkit/BukkitCommandProcessor.java
@@ -89,7 +89,7 @@ final class BukkitCommandProcessor<S> extends AbstractCommandProcessor<CommandSe
     }
 
     static ArrayList<CommandPermission> createPermissions(
-            @NotNull final String[] parentNode,
+            @NotNull final String[] parentNode, // TODO determine usage?
             @NotNull final String[] node,
             @NotNull final String description,
             @NotNull final PermissionDefault permissionDefault

--- a/minecraft/bukkit/src/main/java/dev/triumphteam/cmd/bukkit/BukkitCommandProcessor.java
+++ b/minecraft/bukkit/src/main/java/dev/triumphteam/cmd/bukkit/BukkitCommandProcessor.java
@@ -95,12 +95,8 @@ final class BukkitCommandProcessor<S> extends AbstractCommandProcessor<CommandSe
             @NotNull final PermissionDefault permissionDefault
     ) {
         ArrayList<CommandPermission> permissions = new ArrayList<>();
-
-        List<String> permissionsList = Arrays.asList(parentNode);
-        ListIterator<String> it = permissionsList.listIterator();
-        while(it.hasNext()) {
-            String permissionBuilder = it.next() + node[it.nextIndex()];
-            permissions.add(new CommandPermission(permissionBuilder, description, permissionDefault));
+        for (String permission : node) {
+            permissions.add(new CommandPermission(permission, description, permissionDefault));
         }
 
         return permissions;

--- a/minecraft/bukkit/src/main/java/dev/triumphteam/cmd/bukkit/BukkitCommandProcessor.java
+++ b/minecraft/bukkit/src/main/java/dev/triumphteam/cmd/bukkit/BukkitCommandProcessor.java
@@ -90,14 +90,20 @@ final class BukkitCommandProcessor<S> extends AbstractCommandProcessor<CommandSe
     }
 
     static List<CommandPermission> createPermissions(
-            @NotNull final List<String> parentNode,
-            @NotNull final List<String> node,
+            @NotNull final List<String> parentNodes,
+            @NotNull final List<String> nodes,
             @NotNull final String description,
             @NotNull final PermissionDefault permissionDefault
     ) {
         List<CommandPermission> permissions = new ArrayList<>();
-        for (String permission : node) {
-            permissions.add(new CommandPermission(permission, description, permissionDefault));
+        if(!parentNodes.isEmpty()) {
+            for (String parentNode : parentNodes)
+                for (String node : nodes)
+                    permissions.add(new CommandPermission(parentNode + "." + node, description, permissionDefault));
+        } else {
+            for (String node : nodes) {
+                permissions.add(new CommandPermission(node, description, permissionDefault));
+            }
         }
 
         return permissions;

--- a/minecraft/bukkit/src/main/java/dev/triumphteam/cmd/bukkit/BukkitSubCommand.java
+++ b/minecraft/bukkit/src/main/java/dev/triumphteam/cmd/bukkit/BukkitSubCommand.java
@@ -44,7 +44,10 @@ public final class BukkitSubCommand<S> extends AbstractSubCommand<S> {
         super(processor, parentName, executionProvider);
         this.permissions = processor.getPermissions();
 
-        if (this.permissions != null) this.permissions.forEach(CommandPermission::register);
+        if (this.permissions != null) {
+            this.permissions.forEach(CommandPermission::register);
+            this.permissions.forEach(commandPermission -> System.out.println(commandPermission.getNode() + " for /" + parentName + " " + processor.getName()));
+        }
     }
 
     public List<String> getSuggestions(@NotNull final S sender, @NotNull final List<String> args) {

--- a/minecraft/bukkit/src/main/java/dev/triumphteam/cmd/bukkit/BukkitSubCommand.java
+++ b/minecraft/bukkit/src/main/java/dev/triumphteam/cmd/bukkit/BukkitSubCommand.java
@@ -46,7 +46,6 @@ public final class BukkitSubCommand<S> extends AbstractSubCommand<S> {
 
         if (this.permissions != null) {
             this.permissions.forEach(CommandPermission::register);
-            this.permissions.forEach(commandPermission -> System.out.println(commandPermission.getNode() + " for /" + parentName + " " + processor.getName()));
         }
     }
 

--- a/minecraft/bukkit/src/main/java/dev/triumphteam/cmd/bukkit/BukkitSubCommand.java
+++ b/minecraft/bukkit/src/main/java/dev/triumphteam/cmd/bukkit/BukkitSubCommand.java
@@ -31,19 +31,20 @@ import dev.triumphteam.cmd.core.suggestion.SuggestionContext;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static java.util.Collections.emptyList;
 
 public final class BukkitSubCommand<S> extends AbstractSubCommand<S> {
 
-    private final CommandPermission permission;
+    private final ArrayList<CommandPermission> permissions;
 
     public BukkitSubCommand(@NotNull final BukkitSubCommandProcessor<S> processor, @NotNull final String parentName, @NotNull final ExecutionProvider executionProvider) {
         super(processor, parentName, executionProvider);
-        this.permission = processor.getPermission();
+        this.permissions = processor.getPermissions();
 
-        if (this.permission != null) this.permission.register();
+        if (this.permissions != null) this.permissions.forEach(CommandPermission::register);
     }
 
     public List<String> getSuggestions(@NotNull final S sender, @NotNull final List<String> args) {
@@ -64,7 +65,7 @@ public final class BukkitSubCommand<S> extends AbstractSubCommand<S> {
 
     // TODO: Comments
     @Nullable
-    public CommandPermission getPermission() {
-        return permission;
+    public ArrayList<CommandPermission> getPermissions() {
+        return permissions;
     }
 }

--- a/minecraft/bukkit/src/main/java/dev/triumphteam/cmd/bukkit/BukkitSubCommand.java
+++ b/minecraft/bukkit/src/main/java/dev/triumphteam/cmd/bukkit/BukkitSubCommand.java
@@ -64,7 +64,10 @@ public final class BukkitSubCommand<S> extends AbstractSubCommand<S> {
         return internalArgument.suggestions(sender, trimmed, context);
     }
 
-    // TODO: Comments
+    /**
+     * A {@link List<CommandPermission>} used by this sub-command
+     * @return a list of permissions
+     */
     @Nullable
     public List<CommandPermission> getPermissions() {
         return permissions;

--- a/minecraft/bukkit/src/main/java/dev/triumphteam/cmd/bukkit/BukkitSubCommand.java
+++ b/minecraft/bukkit/src/main/java/dev/triumphteam/cmd/bukkit/BukkitSubCommand.java
@@ -31,14 +31,13 @@ import dev.triumphteam.cmd.core.suggestion.SuggestionContext;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import static java.util.Collections.emptyList;
 
 public final class BukkitSubCommand<S> extends AbstractSubCommand<S> {
 
-    private final ArrayList<CommandPermission> permissions;
+    private final List<CommandPermission> permissions;
 
     public BukkitSubCommand(@NotNull final BukkitSubCommandProcessor<S> processor, @NotNull final String parentName, @NotNull final ExecutionProvider executionProvider) {
         super(processor, parentName, executionProvider);
@@ -67,7 +66,7 @@ public final class BukkitSubCommand<S> extends AbstractSubCommand<S> {
 
     // TODO: Comments
     @Nullable
-    public ArrayList<CommandPermission> getPermissions() {
+    public List<CommandPermission> getPermissions() {
         return permissions;
     }
 }

--- a/minecraft/bukkit/src/main/java/dev/triumphteam/cmd/bukkit/BukkitSubCommandProcessor.java
+++ b/minecraft/bukkit/src/main/java/dev/triumphteam/cmd/bukkit/BukkitSubCommandProcessor.java
@@ -32,10 +32,12 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.stream.Collectors;
 
 final class BukkitSubCommandProcessor<S> extends AbstractSubCommandProcessor<S> {
 
-    private final CommandPermission permission;
+    private ArrayList<CommandPermission> permissions = new ArrayList<>();
 
     public BukkitSubCommandProcessor(
             @NotNull final BaseCommand baseCommand,
@@ -43,18 +45,18 @@ final class BukkitSubCommandProcessor<S> extends AbstractSubCommandProcessor<S> 
             @NotNull final Method method,
             @NotNull final RegistryContainer<S> registryContainer,
             @NotNull final SenderValidator<S> senderValidator,
-            @Nullable final CommandPermission basePermission
+            @Nullable final ArrayList<CommandPermission> basePermissions
     ) {
         super(baseCommand, parentName, method, registryContainer, senderValidator);
 
         final Permission annotation = method.getAnnotation(Permission.class);
         if (annotation == null) {
-            this.permission = basePermission;
+            this.permissions = basePermissions;
             return;
         }
-
-        this.permission = BukkitCommandProcessor.createPermission(
-                basePermission == null ? "" : basePermission.getNode(),
+        String[] permissionStrings = basePermissions.stream().map(CommandPermission::getNode).collect(Collectors.toList()).toArray(new String[0]);
+        permissions = BukkitCommandProcessor.createPermissions(
+                permissionStrings,
                 annotation.value(),
                 annotation.description(),
                 annotation.def()
@@ -62,7 +64,7 @@ final class BukkitSubCommandProcessor<S> extends AbstractSubCommandProcessor<S> 
     }
 
     @Nullable
-    public CommandPermission getPermission() {
-        return permission;
+    public ArrayList<CommandPermission> getPermissions() {
+        return permissions;
     }
 }

--- a/minecraft/bukkit/src/main/java/dev/triumphteam/cmd/bukkit/BukkitSubCommandProcessor.java
+++ b/minecraft/bukkit/src/main/java/dev/triumphteam/cmd/bukkit/BukkitSubCommandProcessor.java
@@ -33,11 +33,10 @@ import org.jetbrains.annotations.Nullable;
 
 import java.lang.reflect.Method;
 import java.util.ArrayList;
-import java.util.stream.Collectors;
 
 final class BukkitSubCommandProcessor<S> extends AbstractSubCommandProcessor<S> {
 
-    private ArrayList<CommandPermission> permissions = new ArrayList<>();
+    private final ArrayList<CommandPermission> permissions;
 
     public BukkitSubCommandProcessor(
             @NotNull final BaseCommand baseCommand,
@@ -54,7 +53,8 @@ final class BukkitSubCommandProcessor<S> extends AbstractSubCommandProcessor<S> 
             this.permissions = basePermissions;
             return;
         }
-        String[] permissionStrings = basePermissions.stream().map(CommandPermission::getNode).collect(Collectors.toList()).toArray(new String[0]);
+        @Nullable String[] permissionStrings = new String[]{""};
+        if(basePermissions != null) permissionStrings = basePermissions.stream().map(CommandPermission::getNode).toArray(String[]::new);
         permissions = BukkitCommandProcessor.createPermissions(
                 permissionStrings,
                 annotation.value(),

--- a/minecraft/bukkit/src/main/java/dev/triumphteam/cmd/bukkit/BukkitSubCommandProcessor.java
+++ b/minecraft/bukkit/src/main/java/dev/triumphteam/cmd/bukkit/BukkitSubCommandProcessor.java
@@ -32,7 +32,10 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 final class BukkitSubCommandProcessor<S> extends AbstractSubCommandProcessor<S> {
 
@@ -53,11 +56,11 @@ final class BukkitSubCommandProcessor<S> extends AbstractSubCommandProcessor<S> 
             this.permissions = basePermissions;
             return;
         }
-        @Nullable String[] permissionStrings = new String[]{""};
-        if(basePermissions != null) permissionStrings = basePermissions.stream().map(CommandPermission::getNode).toArray(String[]::new);
+        @Nullable List<String> permissionList = Collections.singletonList("");
+        if(basePermissions != null) permissionList = basePermissions.stream().map(CommandPermission::getNode).collect(Collectors.toList());
         permissions = BukkitCommandProcessor.createPermissions(
-                permissionStrings,
-                annotation.value(),
+                permissionList,
+                Arrays.stream(annotation.value()).collect(Collectors.toList()),
                 annotation.description(),
                 annotation.def()
         );

--- a/minecraft/bukkit/src/main/java/dev/triumphteam/cmd/bukkit/BukkitSubCommandProcessor.java
+++ b/minecraft/bukkit/src/main/java/dev/triumphteam/cmd/bukkit/BukkitSubCommandProcessor.java
@@ -32,11 +32,11 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.lang.reflect.Method;
-import java.util.ArrayList;
+import java.util.List;
 
 final class BukkitSubCommandProcessor<S> extends AbstractSubCommandProcessor<S> {
 
-    private final ArrayList<CommandPermission> permissions;
+    private final List<CommandPermission> permissions;
 
     public BukkitSubCommandProcessor(
             @NotNull final BaseCommand baseCommand,
@@ -44,7 +44,7 @@ final class BukkitSubCommandProcessor<S> extends AbstractSubCommandProcessor<S> 
             @NotNull final Method method,
             @NotNull final RegistryContainer<S> registryContainer,
             @NotNull final SenderValidator<S> senderValidator,
-            @Nullable final ArrayList<CommandPermission> basePermissions
+            @Nullable final List<CommandPermission> basePermissions
     ) {
         super(baseCommand, parentName, method, registryContainer, senderValidator);
 
@@ -64,7 +64,7 @@ final class BukkitSubCommandProcessor<S> extends AbstractSubCommandProcessor<S> 
     }
 
     @Nullable
-    public ArrayList<CommandPermission> getPermissions() {
+    public List<CommandPermission> getPermissions() {
         return permissions;
     }
 }

--- a/minecraft/bukkit/src/main/java/dev/triumphteam/cmd/bukkit/CommandPermission.java
+++ b/minecraft/bukkit/src/main/java/dev/triumphteam/cmd/bukkit/CommandPermission.java
@@ -55,7 +55,6 @@ final class CommandPermission {
      */
     public void register() {
         final PluginManager pluginManager = Bukkit.getPluginManager();
-        System.out.println(node);
         // Don't register if already registered
         final Permission permission = pluginManager.getPermission(node);
         if (permission != null) return;

--- a/minecraft/bukkit/src/main/java/dev/triumphteam/cmd/bukkit/annotation/Permission.java
+++ b/minecraft/bukkit/src/main/java/dev/triumphteam/cmd/bukkit/annotation/Permission.java
@@ -42,7 +42,7 @@ public @interface Permission {
      *
      * @return The permission's main node.
      */
-    String value();
+    String[] value();
 
     /**
      * Represents the possible default values for permissions.


### PR DESCRIPTION
Closes https://github.com/TriumphTeam/triumph-cmds/issues/62

Syntax: ``@Permission({"plugin.justhiscommand", "plugin.everything"})``

Original syntax can still be used: ``@Permission("plugin.freediamonds")``