### PR TITLE
fix: Fix suggestion permissions

### DIFF
--- a/minecraft/bukkit/src/main/java/dev/triumphteam/cmd/bukkit/BukkitCommand.java
+++ b/minecraft/bukkit/src/main/java/dev/triumphteam/cmd/bukkit/BukkitCommand.java
@@ -94,7 +94,7 @@ public final class BukkitCommand<S> extends org.bukkit.command.Command implement
         }
 
         final CommandPermission permission = subCommand.getPermission();
-        if (permission != null && !permission.hasPermission(sender)) {
+        if (!CommandPermission.hasPermission(sender, permission)) {
             messageRegistry.sendMessage(BukkitMessageKey.NO_PERMISSION, mappedSender, new NoPermissionMessageContext(getName(), subCommand.getName(), permission));
             return true;
         }
@@ -118,8 +118,7 @@ public final class BukkitCommand<S> extends org.bukkit.command.Command implement
                     .filter(it -> it.getKey().startsWith(arg))
                     .filter(it -> {
                         final CommandPermission permission = it.getValue().getPermission();
-                        if (permission == null) return false;
-                        return permission.hasPermission(sender);
+                        return CommandPermission.hasPermission(sender, permission);
                     })
                     .map(Map.Entry::getKey)
                     .collect(Collectors.toList());
@@ -129,7 +128,7 @@ public final class BukkitCommand<S> extends org.bukkit.command.Command implement
         if (subCommand == null) return emptyList();
 
         final CommandPermission permission = subCommand.getPermission();
-        if (permission != null && permission.hasPermission(sender)) return emptyList();
+        if (!CommandPermission.hasPermission(sender, permission)) return emptyList();
 
         final S mappedSender = senderMapper.map(sender);
         if (mappedSender == null) {

--- a/minecraft/bukkit/src/main/java/dev/triumphteam/cmd/bukkit/CommandPermission.java
+++ b/minecraft/bukkit/src/main/java/dev/triumphteam/cmd/bukkit/CommandPermission.java
@@ -29,6 +29,7 @@ import org.bukkit.permissions.Permission;
 import org.bukkit.permissions.PermissionDefault;
 import org.bukkit.plugin.PluginManager;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -51,6 +52,26 @@ public final class CommandPermission {
         this.nodes = nodes;
         this.description = description;
         this.permissionDefault = permissionDefault;
+    }
+
+    /**
+     * Checks whether the {@link CommandSender} has the (nullable) {@link CommandPermission}.
+     * <p>
+     * The method simply checks if any of the following two things are {@code true}:
+     * <ul>
+     *     <li>The permission is {@code null}</li>
+     *     <li>The sender has the permission</li>
+     * </ul>
+     *
+     * @param sender The main command sender.
+     * @param permission The permission.
+     * @return Whether the sender has permission to run the command.
+     */
+    public static boolean hasPermission(
+            final @NotNull CommandSender sender,
+            final @Nullable CommandPermission permission
+    ) {
+        return permission == null || permission.hasPermission(sender);
     }
 
     public @NotNull CommandPermission child(


### PR DESCRIPTION
Looks like a hasPermission was accidentally inverted in 1 place and there's also a few different handlings of `null` permissions so I've made a simply utility method to make sure it's consistent and more readable.

Closes #82 